### PR TITLE
Stop listening for animation status changes after the villain is disposed

### DIFF
--- a/lib/villains/villains.dart
+++ b/lib/villains/villains.dart
@@ -101,6 +101,11 @@ class Villain extends StatefulWidget {
 class _VillainState extends State<Villain> {
   Animation<double> _controllerAnimation;
 
+  @override
+  void dispose() {
+    _controllerAnimation?.removeStatusListener(_handleStatusChange);
+    super.dispose();
+  }
 
   void startAnimation(Animation<double> animation) {
     assert(animation != null);
@@ -116,7 +121,6 @@ class _VillainState extends State<Villain> {
       return _controllerAnimation;
     }
     return AlwaysStoppedAnimation<double>(1.0);
-
   }
 
   void _handleStatusChange(AnimationStatus status) {


### PR DESCRIPTION
Fixes https://github.com/Norbert515/flutter_villains/issues/8